### PR TITLE
Summer24 Campaign Multithreading Fix

### DIFF
--- a/campaigns/Run3Summer24wmLHEGS/run.sh
+++ b/campaigns/Run3Summer24wmLHEGS/run.sh
@@ -37,9 +37,9 @@ else
 fi
 
 if [ -z "$5" ]; then
-    MAX_NTHREADS=1
+    MAX_NTHREADS=8
 else
-    MAX_NTHREADS=1
+    MAX_NTHREADS=$5
 fi
 RSEED=$((JOBINDEX * MAX_NTHREADS * 4 + 1001 + $RANDOM)) # Space out seeds; Madgraph concurrent mode adds idx(thread) to random seed. The extra *4 is a paranoia factor.
 


### PR DESCRIPTION
bypassed multitreading options in Sum24 for local debugging and accidentally committed when first PR'd Summer24. condor would request n cores, but the jobs would run with only 1.  